### PR TITLE
Build for PG 9.3 - 9.6 with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,45 @@
+FROM ubuntu:xenial
+MAINTAINER Drazen Urch <github@drazenur.ch>
+
+ARG PG_VER=9.6
+ARG RUST_VER=1.13.0
+
+ENV USER root
+
+RUN apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    software-properties-common \
+    python-software-properties \
+    wget
+RUN add-apt-repository "deb http://apt.postgresql.org/pub/repos/apt/ xenial-pgdg main" && \
+    wget --quiet -O - https://www.postgresql.org/media/keys/ACCC4CF8.asc | apt-key add -  && \
+    apt-get update && \
+    DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+        build-essential \
+        ca-certificates \
+        curl \
+        musl-tools \
+        clang \
+        libclang-dev \
+        git \
+        libssl-dev \
+        bc \
+        postgresql-server-dev-${PG_VER}
+RUN curl -sO https://static.rust-lang.org/dist/rust-${RUST_VER}-x86_64-unknown-linux-gnu.tar.gz && \
+    tar -xzf rust-${RUST_VER}-x86_64-unknown-linux-gnu.tar.gz && \
+    ./rust-${RUST_VER}-x86_64-unknown-linux-gnu/install.sh --without=rust-docs && \
+    curl -sO https://static.rust-lang.org/dist/rust-std-${RUST_VER}-x86_64-unknown-linux-musl.tar.gz && \
+    tar -xzf rust-std-${RUST_VER}-x86_64-unknown-linux-musl.tar.gz && \
+    ./rust-std-${RUST_VER}-x86_64-unknown-linux-musl/install.sh --without=rust-docs
+RUN cargo install bindgen
+
+RUN DEBIAN_FRONTEND=noninteractive apt-get remove --purge -y curl && \
+    DEBIAN_FRONTEND=noninteractive apt-get autoremove -y
+RUN rm -rf \
+    rust-std-${RUST_VER}-x86_64-unknown-linux-musl \
+    rust-${RUST_VER}-x86_64-unknown-linux-gnu \
+    rust-std-${RUST_VER}-x86_64-unknown-linux-musl.tar.gz \
+    rust-${RUST_VER}-x86_64-unknown-linux-gnu.tar.gz \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,34 @@
+version: '2'
+services:
+  rpgffi96:
+    environment:
+      - PATH=$PATH:/root/.cargo/bin
+    build:
+      context: .
+      dockerfile: Dockerfile
+      args:
+        - PG_VER=9.6
+        - RUST_VER=1.13.0
+    volumes:
+      - .:/source
+    working_dir: /source
+    command: util/generate_bindings
+  rpgffi95:
+    extends:
+      service: rpgffi96
+    build:
+      args:
+        - PG_VER=9.5
+  rpgffi94:
+    extends:
+      service: rpgffi95
+    build:
+      args:
+        - PG_VER=9.4
+  rpgffi93:
+    extends:
+      service: rpgffi94
+    build:
+      args:
+        - PG_VER=9.3
+


### PR DESCRIPTION
Allows for quick and consistent testing of builds, can easily be extended to support more configurations.

@posix4e please have a look